### PR TITLE
サブプロセスを使わずgdalwarp使うようにフィチャー

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
-/DEM/
+*DEM/
 /GeoTiff/
 /test_generated/
 /target_files/
+*.pyc
+*__pycache__/

--- a/convert_fgd_dem/converter.py
+++ b/convert_fgd_dem/converter.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-
 import numpy as np
 from rio_rgbify.encoders import data_to_rgb
 from riomucho import RioMucho
@@ -24,7 +23,7 @@ def rgbify(
 ):
     """rio-rgbify method."""
     workers = 4
-    with rio.open(src_path) as src:
+    with rio.open(src_path, dtype=np.int16) as src:
         meta = src.profile.copy()
     meta.update(count=3, dtype=np.uint8)
 
@@ -125,7 +124,7 @@ class Converter:
 
         # 全xmlを包括する配列を作成
         dem_array = np.empty((y_length, x_length), np.float32)
-        dem_array.fill(-9999)
+        dem_array.fill(0)
 
         x_pixel_size = (
             self.dem.bounds_latlng["upper_right"]["lon"]
@@ -194,7 +193,7 @@ class Converter:
         filled_dem_path = self.output_path / "nodata_none.tif"
         warp(
             source_path=src_path.resolve(),
-            file_name=filled_dem_path.resolve(),
+            file_name="nodata_none.tif",
             epsg=self.output_epsg,
             output_path=self.output_path,
         )

--- a/convert_fgd_dem/converter.py
+++ b/convert_fgd_dem/converter.py
@@ -23,7 +23,7 @@ def rgbify(
 ):
     """rio-rgbify method."""
     workers = 4
-    with rio.open(src_path, dtype=np.int16) as src:
+    with rio.open(src_path) as src:
         meta = src.profile.copy()
     meta.update(count=3, dtype=np.uint8)
 
@@ -124,7 +124,7 @@ class Converter:
 
         # 全xmlを包括する配列を作成
         dem_array = np.empty((y_length, x_length), np.float32)
-        dem_array.fill(0)
+        dem_array.fill(-9999)
 
         x_pixel_size = (
             self.dem.bounds_latlng["upper_right"]["lon"]

--- a/convert_fgd_dem/converter.py
+++ b/convert_fgd_dem/converter.py
@@ -1,4 +1,3 @@
-import subprocess
 from pathlib import Path
 
 import numpy as np
@@ -8,6 +7,7 @@ import rasterio as rio
 
 from convert_fgd_dem.dem import Dem
 from convert_fgd_dem.geotiff import Geotiff
+from convert_fgd_dem.helpers import warp
 
 
 def _rgb_worker(data, window, ij, g_args):
@@ -192,8 +192,12 @@ class Converter:
         src_path = self.output_path / "output.tif"
 
         filled_dem_path = self.output_path / "nodata_none.tif"
-        warp_cmd = f"gdalwarp -overwrite -t_srs {self.output_epsg} -dstnodata None {src_path.resolve()} {filled_dem_path.resolve()}"
-        subprocess.check_output(warp_cmd, shell=True)
+        warp(
+            source_path=src_path.resolve(),
+            file_name=filled_dem_path.resolve(),
+            epsg=self.output_epsg,
+            output_path=self.output_path,
+        )
 
         rgb_path = self.output_path / "rgbify.tif"
         rgbify(

--- a/convert_fgd_dem/geotiff.py
+++ b/convert_fgd_dem/geotiff.py
@@ -77,7 +77,7 @@ class Geotiff:
             source_path=None,
             file_name="output.tif",
             epsg="EPSG:3857",
-            no_data_value=-9999):
+            no_data_value=0):
         """EPSG:4326のTiffから新たなGeoTiffを出力する
 
         Args:

--- a/convert_fgd_dem/geotiff.py
+++ b/convert_fgd_dem/geotiff.py
@@ -34,10 +34,9 @@ class Geotiff:
         self.x_length = x_length
         self.y_length = y_length
         self.output_path: Path = output_path
-        # TODO Noneよりディフォルトパス書いたほうがいいかな？
-        self.created_tiff_path: Path = None
+        self.created_tiff_path: Path = self.output_path / "output.tif"
 
-    def write_geotiff(self, file_name="output.tif", no_data_value=-9999):
+    def write_geotiff(self, file_name="output.tif", no_data_value=0):
         """標高と座標、ピクセルサイズ、グリッドサイズからGeoTiffを作成
 
         Args:

--- a/convert_fgd_dem/geotiff.py
+++ b/convert_fgd_dem/geotiff.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 from osgeo import gdal, osr
+from convert_fgd_dem.helpers import warp
 
 
 class Geotiff:
@@ -33,7 +34,7 @@ class Geotiff:
         self.x_length = x_length
         self.y_length = y_length
         self.output_path: Path = output_path
-
+        # TODO Noneよりディフォルトパス書いたほうがいいかな？
         self.created_tiff_path: Path = None
 
     def write_geotiff(self, file_name="output.tif", no_data_value=-9999):
@@ -88,19 +89,10 @@ class Geotiff:
         """
         if source_path is None:
             source_path = self.created_tiff_path
-
-        if file_name is None:
-            file_name = "".join(f"dem_{epsg.lower()}.tif".split(":"))
-
-        warp_path = str((self.output_path / file_name).resolve())
-        src_path = str(source_path.resolve())
-
-        resampled_ras = gdal.Warp(
-            warp_path,
-            src_path,
-            srcSRS="EPSG:4326",
-            dstSRS=epsg,
-            dstNodata=no_data_value,
-            resampleAlg="near",
+        warp(
+            source_path=source_path,
+            file_name=file_name,
+            epsg=epsg,
+            output_path=self.output_path,
+            no_data_value=no_data_value
         )
-        resampled_ras.FlushCache()

--- a/convert_fgd_dem/geotiff.py
+++ b/convert_fgd_dem/geotiff.py
@@ -76,7 +76,7 @@ class Geotiff:
             source_path=None,
             file_name="output.tif",
             epsg="EPSG:3857",
-            no_data_value=0):
+            no_data_value=-9999):
         """EPSG:4326のTiffから新たなGeoTiffを出力する
 
         Args:

--- a/convert_fgd_dem/geotiff.py
+++ b/convert_fgd_dem/geotiff.py
@@ -36,7 +36,7 @@ class Geotiff:
         self.output_path: Path = output_path
         self.created_tiff_path: Path = self.output_path / "output.tif"
 
-    def write_geotiff(self, file_name="output.tif", no_data_value=0):
+    def write_geotiff(self, file_name="output.tif", no_data_value=-9999):
         """標高と座標、ピクセルサイズ、グリッドサイズからGeoTiffを作成
 
         Args:

--- a/convert_fgd_dem/helpers.py
+++ b/convert_fgd_dem/helpers.py
@@ -6,7 +6,7 @@ def warp(
         file_name="output.tif",
         output_path=None,
         epsg="EPSG:3857",
-        no_data_value=0):
+        no_data_value="None"):
     """
     EPSG:4326のTiffから新たなGeoTiffを出力する
 

--- a/convert_fgd_dem/helpers.py
+++ b/convert_fgd_dem/helpers.py
@@ -1,0 +1,41 @@
+from osgeo import gdal
+
+
+def warp(
+        source_path=None,
+        file_name="output.tif",
+        output_path=None,
+        epsg="EPSG:3857",
+        no_data_value=0):
+    """
+    EPSG:4326のTiffから新たなGeoTiffを出力する
+
+    Args:
+        source_path (Path or None):
+        file_name (str):
+        output_path (Path or None):
+        epsg (str):
+        no_data_value (int):
+
+    """
+
+    if not output_path.exists():
+        output_path.mkdir()
+    if source_path is None:
+        source_path = output_path / file_name
+
+    if file_name is None:
+        file_name = "".join(f"dem_{epsg.lower()}.tif".split(":"))
+
+    warp_path = str((output_path / file_name).resolve())
+    src_path = str(source_path.resolve())
+
+    resampled_ras = gdal.Warp(
+        warp_path,
+        src_path,
+        srcSRS="EPSG:4326",
+        dstSRS=epsg,
+        dstNodata=no_data_value,
+        resampleAlg="near"
+    )
+    resampled_ras.FlushCache()


### PR DESCRIPTION
このPRに入ってるフィチャーやフィクス：

- コードにをちょっときれいにしました。不要なvalidationを消しました。
- `no_data_value` の最低なvalueを0にしました。理由は　`np.uint`は0-255 ので -99999にしたらエラーが出るはずだ。
- オブジェクトのgdalwarpをよく使うのでhelperにしました。

PS: マージをする前に出力を確認してください。間違いところあるかどうかわかりませんです。
